### PR TITLE
Add initial GitLab OpenAI agent skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# test_project
+# GitLab OpenAI Agent
+
+This project provides a basic framework for building an automation agent that
+integrates GitLab with the OpenAI API. The agent can analyze repositories,
+propose fixes, and generate summaries or new code.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Create a configuration JSON file or set environment variables `OPENAI_API_KEY`
+and `GITLAB_TOKEN`. Example `config.json`:
+
+```json
+{
+  "openai_api_key": "sk-...",
+  "gitlab_token": "glpat-...",
+  "gitlab_url": "https://gitlab.com"
+}
+```
+
+## Usage
+
+Run the agent from the command line:
+
+```bash
+python main.py <project-id-or-path> --config config.json
+```
+
+This will produce an OpenAI-generated summary of the specified GitLab project.
+

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,13 @@
+"""Entry point for the agent package."""
+
+from .config import AgentConfig
+from .openai_client import OpenAIClient
+from .gitlab_client import GitLabClient
+from .actions import AgentActions
+
+__all__ = [
+    "AgentConfig",
+    "OpenAIClient",
+    "GitLabClient",
+    "AgentActions",
+]

--- a/agent/actions.py
+++ b/agent/actions.py
@@ -1,0 +1,26 @@
+"""High-level actions performed by the agent."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .openai_client import OpenAIClient
+from .gitlab_client import GitLabClient
+
+
+class AgentActions:
+    """Collection of operations that combine GitLab and OpenAI."""
+
+    def __init__(self, openai_client: OpenAIClient, gitlab_client: GitLabClient) -> None:
+        self.openai = openai_client
+        self.gitlab = gitlab_client
+
+    def summarize_project(self, project_id: str | int) -> str:
+        """Generate a summary of a GitLab project using OpenAI."""
+        project = self.gitlab.get_project(project_id)
+        messages = [
+            {"role": "system", "content": "You are a coding assistant."},
+            {"role": "user", "content": f"Summarize the GitLab project: {project.path_with_namespace}"},
+        ]
+        return self.openai.chat(messages)
+

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,29 @@
+"""Configuration utilities for the agent."""
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import os
+
+
+@dataclass
+class AgentConfig:
+    """Configuration parameters for the agent."""
+
+    openai_api_key: str
+    gitlab_token: str
+    gitlab_url: str = "https://gitlab.com"
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> "AgentConfig":
+        """Load configuration from a JSON file or environment variables."""
+        data = {}
+        if path:
+            with open(path) as fh:
+                data = json.load(fh)
+        return cls(
+            openai_api_key=data.get("openai_api_key") or os.getenv("OPENAI_API_KEY", ""),
+            gitlab_token=data.get("gitlab_token") or os.getenv("GITLAB_TOKEN", ""),
+            gitlab_url=data.get("gitlab_url") or os.getenv("GITLAB_URL", "https://gitlab.com"),
+        )
+

--- a/agent/gitlab_client.py
+++ b/agent/gitlab_client.py
@@ -1,0 +1,18 @@
+"""Utilities for interacting with GitLab."""
+
+from __future__ import annotations
+
+import gitlab
+from gitlab.v4.objects import Project
+
+
+class GitLabClient:
+    """Wrapper around python-gitlab."""
+
+    def __init__(self, token: str, url: str = "https://gitlab.com") -> None:
+        self.gl = gitlab.Gitlab(url, private_token=token)
+
+    def get_project(self, project_id: str | int) -> Project:
+        """Fetch a GitLab project."""
+        return self.gl.projects.get(project_id)
+

--- a/agent/openai_client.py
+++ b/agent/openai_client.py
@@ -1,0 +1,20 @@
+"""Wrapper around the OpenAI API."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import openai
+
+
+class OpenAIClient:
+    """Simple wrapper for OpenAI API interactions."""
+
+    def __init__(self, api_key: str) -> None:
+        openai.api_key = api_key
+
+    def chat(self, messages: Iterable[dict], model: str = "gpt-4", **kwargs) -> str:
+        """Send chat completion request and return the reply content."""
+        response = openai.ChatCompletion.create(model=model, messages=list(messages), **kwargs)
+        return response["choices"][0]["message"]["content"]
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+"""Command-line interface for the agent."""
+
+from __future__ import annotations
+
+import argparse
+
+from agent import AgentConfig, OpenAIClient, GitLabClient, AgentActions
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GitLab automation agent")
+    parser.add_argument("project", help="GitLab project ID or path")
+    parser.add_argument("--config", help="Path to config JSON file")
+    args = parser.parse_args()
+
+    config = AgentConfig.load(args.config)
+    openai_client = OpenAIClient(config.openai_api_key)
+    gitlab_client = GitLabClient(config.gitlab_token, config.gitlab_url)
+    actions = AgentActions(openai_client, gitlab_client)
+
+    summary = actions.summarize_project(args.project)
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gitlab-openai-agent"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=1.0",
+    "python-gitlab>=3.10",
+    "GitPython>=3.1",
+]
+
+[project.scripts]
+agent = "main:main"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.0
+python-gitlab>=3.10
+GitPython>=3.1
+


### PR DESCRIPTION
## Summary
- initialize `agent` package for GitLab/OpenAI integration
- provide CLI entrypoint
- configure dependencies via `pyproject.toml` and `requirements.txt`
- expand README with usage instructions

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684707d5f89c8332bff66125712f6c28